### PR TITLE
Allow rendering custom errors

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -8,6 +8,7 @@ LineLength:
 
 StringLiterals:
   Enabled: false
+  EnforcedStyle: single_quotes
 
 TrailingBlankLines:
   Enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,2 @@
 ruby:
-  config_file: config/.rubocop.yml
+  config_file: .rubocop.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,14 +1,2 @@
-AllCops:
-  Exclude:
-    - "spec/dummy/db/*"
-
-LineLength:
-  Exclude:
-    - spec/**/*
-
-StringLiterals:
-  Enabled: false
-  EnforcedStyle: single_quotes
-
-TrailingBlankLines:
-  Enabled: true
+ruby:
+  config_file: config/.rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+AllCops:
+  Exclude:
+    - "spec/dummy/db/*"
+
+LineLength:
+  Exclude:
+    - spec/**/*
+
+StringLiterals:
+  Enabled: false
+
+TrailingBlankLines:
+  Enabled: true

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -3,6 +3,7 @@ require 'doorkeeper/engine'
 require 'doorkeeper/config'
 
 require 'doorkeeper/errors'
+require 'doorkeeper/exception_raiser'
 require 'doorkeeper/server'
 require 'doorkeeper/request'
 require 'doorkeeper/validations'

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -243,6 +243,7 @@ doorkeeper.
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
+    option :handle_auth_errors,             default: :render
     option :access_token_generator,
            default: 'Doorkeeper::OAuth::Helpers::UniqueToken'
     option :base_controller,

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -36,19 +36,13 @@ module Doorkeeper
       end
     end
 
-    class UnableToGenerateToken < DoorkeeperError
-    end
+    UnableToGenerateToken = Class.new DoorkeeperError
+    TokenGeneratorNotFound = Class.new DoorkeeperError
 
-    class TokenGeneratorNotFound < DoorkeeperError
-    end
-
-    class TokenExpired < DoorkeeperError
-    end
-    class TokenRevoked < DoorkeeperError
-    end
-    class TokenUnknown < DoorkeeperError
-    end
-    class TokenForbidden < DoorkeeperError
-    end
+    InvalidToken = Class.new DoorkeeperError
+    TokenExpired = Class.new InvalidToken
+    TokenRevoked = Class.new InvalidToken
+    TokenUnknown = Class.new InvalidToken
+    TokenForbidden = Class.new InvalidToken
   end
 end

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -41,5 +41,14 @@ module Doorkeeper
 
     class TokenGeneratorNotFound < DoorkeeperError
     end
+
+    class TokenExpired < DoorkeeperError
+    end
+    class TokenRevoked < DoorkeeperError
+    end
+    class TokenUnknown < DoorkeeperError
+    end
+    class TokenForbidden < DoorkeeperError
+    end
   end
 end

--- a/lib/doorkeeper/exception_raiser.rb
+++ b/lib/doorkeeper/exception_raiser.rb
@@ -1,7 +1,5 @@
 module Doorkeeper
   class ExceptionRaiser
-    attr_reader :error
-
     def initialize(error)
       @error = error
     end
@@ -9,13 +7,15 @@ module Doorkeeper
     def raise_if_handled
       return unless raise_errors?
 
-      raise_invalid_token if error.is_a? OAuth::InvalidTokenResponse
+      raise_invalid_token_error if error.is_a? OAuth::InvalidTokenResponse
       raise Doorkeeper::Errors::TokenForbidden, error.description if error.is_a? OAuth::ForbiddenTokenResponse
     end
 
     private
 
-    def raise_invalid_token
+    attr_reader :error
+
+    def raise_invalid_token_error
       errors = {
           expired: Doorkeeper::Errors::TokenExpired,
           revoked: Doorkeeper::Errors::TokenRevoked,

--- a/lib/doorkeeper/exception_raiser.rb
+++ b/lib/doorkeeper/exception_raiser.rb
@@ -8,7 +8,9 @@ module Doorkeeper
       return unless raise_errors?
 
       raise_invalid_token_error if error.is_a? OAuth::InvalidTokenResponse
-      raise Doorkeeper::Errors::TokenForbidden, error.description if error.is_a? OAuth::ForbiddenTokenResponse
+      if error.is_a? OAuth::ForbiddenTokenResponse
+        raise Doorkeeper::Errors::TokenForbidden, error.description
+      end
     end
 
     private
@@ -17,9 +19,9 @@ module Doorkeeper
 
     def raise_invalid_token_error
       errors = {
-          expired: Doorkeeper::Errors::TokenExpired,
-          revoked: Doorkeeper::Errors::TokenRevoked,
-          unknown: Doorkeeper::Errors::TokenUnknown
+        expired: Doorkeeper::Errors::TokenExpired,
+        revoked: Doorkeeper::Errors::TokenRevoked,
+        unknown: Doorkeeper::Errors::TokenUnknown
       }
 
       raise errors[error.reason], error.description

--- a/lib/doorkeeper/exception_raiser.rb
+++ b/lib/doorkeeper/exception_raiser.rb
@@ -1,0 +1,32 @@
+module Doorkeeper
+  class ExceptionRaiser
+    attr_reader :error
+
+    def initialize(error)
+      @error = error
+    end
+
+    def raise_if_handled
+      return unless raise_errors?
+
+      raise_invalid_token if error.is_a? OAuth::InvalidTokenResponse
+      raise Doorkeeper::Errors::TokenForbidden, error.description if error.is_a? OAuth::ForbiddenTokenResponse
+    end
+
+    private
+
+    def raise_invalid_token
+      errors = {
+          expired: Doorkeeper::Errors::TokenExpired,
+          revoked: Doorkeeper::Errors::TokenRevoked,
+          unknown: Doorkeeper::Errors::TokenUnknown
+      }
+
+      raise errors[error.reason], error.description
+    end
+
+    def raise_errors?
+      Doorkeeper.configuration.handle_auth_errors == :raise
+    end
+  end
+end

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -23,6 +23,8 @@ module Doorkeeper
 
       def doorkeeper_render_error
         error = doorkeeper_error
+        Doorkeeper::ExceptionRaiser.new(error).raise_if_handled
+
         headers.merge! error.headers.reject { |k| "Content-Type" == k }
         doorkeeper_render_error_with(error)
       end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -109,4 +109,16 @@ Doorkeeper.configure do
 
   # WWW-Authenticate Realm (default "Doorkeeper").
   # realm "Doorkeeper"
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself, set
+  # handle_auth_errors = :raise
+  # and rescue following errors:
+  # Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  # Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors = :raise
 end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -116,7 +116,8 @@ Doorkeeper.configure do
   #
   # If you want to render error response yourself, set
   # handle_auth_errors = :raise
-  # and rescue following errors:
+  # and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
   # Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
   # Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
   #

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -297,4 +297,46 @@ describe 'doorkeeper authorize filter' do
       end
     end
   end
+
+  context 'when handle_auth_errors option is set to :raise' do
+    before do
+      config_is_set(:handle_auth_errors, :raise)
+    end
+
+    controller do
+      before_action :doorkeeper_authorize!
+
+      include ControllerActions
+    end
+
+    context 'and token is unknown' do
+      it 'raises Doorkeeper::Errors::TokenUnknown exception', token: :invalid do
+        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenUnknown)
+      end
+    end
+
+    context 'and token is expired' do
+      it 'raises Doorkeeper::Errors::TokenExpired exception', token: :expired do
+        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenExpired)
+      end
+    end
+
+    context 'and token is revoked' do
+      it 'raises Doorkeeper::Errors::TokenRevoked exception', token: :revoked do
+        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenRevoked)
+      end
+    end
+
+    context 'and token is forbidden' do
+      it 'raises Doorkeeper::Errors::TokenForbidden exception', token: :forbidden do
+        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenForbidden)
+      end
+    end
+
+    context 'and token is valid' do
+      it 'allows into index action', token: :valid do
+        expect(response).to be_success
+      end
+    end
+  end
 end

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -299,6 +299,7 @@ describe 'doorkeeper authorize filter' do
   end
 
   context 'when handle_auth_errors option is set to :raise' do
+    subject { get :index, access_token: token_string }
     before do
       config_is_set(:handle_auth_errors, :raise)
     end
@@ -309,31 +310,31 @@ describe 'doorkeeper authorize filter' do
       include ControllerActions
     end
 
-    context 'and token is unknown' do
+    context 'when token is unknown' do
       it 'raises Doorkeeper::Errors::TokenUnknown exception', token: :invalid do
-        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenUnknown)
+        expect { subject }.to raise_error(Doorkeeper::Errors::TokenUnknown)
       end
     end
 
-    context 'and token is expired' do
+    context 'when token is expired' do
       it 'raises Doorkeeper::Errors::TokenExpired exception', token: :expired do
-        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenExpired)
+        expect { subject }.to raise_error(Doorkeeper::Errors::TokenExpired)
       end
     end
 
-    context 'and token is revoked' do
+    context 'when token is revoked' do
       it 'raises Doorkeeper::Errors::TokenRevoked exception', token: :revoked do
-        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenRevoked)
+        expect { subject }.to raise_error(Doorkeeper::Errors::TokenRevoked)
       end
     end
 
-    context 'and token is forbidden' do
+    context 'when token is forbidden' do
       it 'raises Doorkeeper::Errors::TokenForbidden exception', token: :forbidden do
-        expect{ get :index, access_token: token_string }.to raise_error(Doorkeeper::Errors::TokenForbidden)
+        expect { subject }.to raise_error(Doorkeeper::Errors::TokenForbidden)
       end
     end
 
-    context 'and token is valid' do
+    context 'when token is valid' do
       it 'allows into index action', token: :valid do
         expect(response).to be_success
       end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -331,4 +331,18 @@ describe Doorkeeper, 'configuration' do
       it { expect(Doorkeeper.configuration.base_controller).to eq('ApplicationController') }
     end
   end
+
+  describe 'handle_auth_errors' do
+    it 'is set to render by default' do
+      expect(Doorkeeper.configuration.handle_auth_errors).to eq(:render)
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure {
+        orm DOORKEEPER_ORM
+        handle_auth_errors :raise
+      }
+      expect(subject.handle_auth_errors).to eq(:raise)
+    end
+  end
 end

--- a/spec/support/shared/controllers_shared_context.rb
+++ b/spec/support/shared/controllers_shared_context.rb
@@ -49,7 +49,7 @@ shared_context 'expired token', token: :expired do
 
   before :each do
     allow(
-        Doorkeeper::AccessToken
+      Doorkeeper::AccessToken
     ).to receive(:by_token).with(token_string).and_return(token)
   end
 end
@@ -68,7 +68,7 @@ shared_context 'revoked token', token: :revoked do
 
   before :each do
     allow(
-        Doorkeeper::AccessToken
+      Doorkeeper::AccessToken
     ).to receive(:by_token).with(token_string).and_return(token)
   end
 end
@@ -86,7 +86,7 @@ shared_context 'forbidden token', token: :forbidden do
 
   before :each do
     allow(
-        Doorkeeper::AccessToken
+      Doorkeeper::AccessToken
     ).to receive(:by_token).with(token_string).and_return(token)
   end
 end

--- a/spec/support/shared/controllers_shared_context.rb
+++ b/spec/support/shared/controllers_shared_context.rb
@@ -35,6 +35,62 @@ shared_context 'invalid token', token: :invalid do
   end
 end
 
+shared_context 'expired token', token: :expired do
+  let :token_string do
+    '1A2B3C4DEXP'
+  end
+
+  let :token do
+    double(Doorkeeper::AccessToken,
+           accessible?: false, revoked?: false, expired?: true,
+           includes_scope?: false, acceptable?: false,
+           previous_refresh_token: "", revoke_previous_refresh_token!: true)
+  end
+
+  before :each do
+    allow(
+        Doorkeeper::AccessToken
+    ).to receive(:by_token).with(token_string).and_return(token)
+  end
+end
+
+shared_context 'revoked token', token: :revoked do
+  let :token_string do
+    '1A2B3C4DREV'
+  end
+
+  let :token do
+    double(Doorkeeper::AccessToken,
+           accessible?: false, revoked?: true, expired?: false,
+           includes_scope?: false, acceptable?: false,
+           previous_refresh_token: "", revoke_previous_refresh_token!: true)
+  end
+
+  before :each do
+    allow(
+        Doorkeeper::AccessToken
+    ).to receive(:by_token).with(token_string).and_return(token)
+  end
+end
+
+shared_context 'forbidden token', token: :forbidden do
+  let :token_string do
+    '1A2B3C4DFORB'
+  end
+
+  let :token do
+    double(Doorkeeper::AccessToken,
+           accessible?: true, includes_scope?: true, acceptable?: false,
+           previous_refresh_token: "", revoke_previous_refresh_token!: true)
+  end
+
+  before :each do
+    allow(
+        Doorkeeper::AccessToken
+    ).to receive(:by_token).with(token_string).and_return(token)
+  end
+end
+
 shared_context 'authenticated resource owner' do
   before do
     user = double(:resource, id: 1)


### PR DESCRIPTION
## Description
Allow rendering custom errors

Set handle_auth_errors = :raise in initializer to raise exceptions insteads rendering response on unauthorized requests.

## Ticket
https://github.com/doorkeeper-gem/doorkeeper/issues/844
https://netguru.atlassian.net/browse/OS-3